### PR TITLE
support multi application synchronization

### DIFF
--- a/lib/reuse_query_results/storage.rb
+++ b/lib/reuse_query_results/storage.rb
@@ -1,58 +1,67 @@
 module ReuseQueryResults
-  module Storage
-    class Base
-      def add(database, table, sql, result)
-        raise NotImplementedError
-      end
-
-      def fetch(database, table, sql)
-        raise NotImplementedError
-      end
-
-      def clear(database, table)
-        raise NotImplementedError
-      end
-
-      def fetch_or_execute(database, key, sql, &block)
-        cached_result = fetch(database, key, sql)
-        if cached_result
-          Rails.logger.debug("HIT REUSE CACHE: #{sql}")
-          return cached_result
-        end
-        block.call.tap { |result| add(database, key, sql, result) }
-      end
-
-      def clear_and_execute(database, table, &block)
-        clear(database, table)
-        block.call
-      end
+  class Storage
+    attr_reader :databases
+    def initialize(sync_client: nil)
+      @sync_client = sync_client
+      clear_all
     end
 
-    class Memory < Base
-      attr_reader :databases
-      def initialize
-        clear_all
-      end
+    def add(database, tables, sql, result)
+      @databases[database][tables][sql] = { data: result, timestamp: Time.now.to_i }
+    end
 
-      def add(database, key, sql, result)
-        @databases[database][key][sql] = result
+    def clear_all
+      @databases = Hash.new do |h, k| 
+        h[k] = Hash.new { |h2, k2| h2[k2] = {} }
       end
+      return unless sync_mode?
+      @sync_client.clear
+    end
 
-      def fetch(database, key, sql)
-        @databases[database][key][sql]
+    def clear(database, table)
+      @databases[database].keys.select { |tables|
+        tables.include?(table)
+      }.each { |tables| 
+        @databases[database][tables] = {}
+      }
+      return unless sync_mode?
+      update_modified_timestamp(database, table)
+    end
+
+    def fetch_or_execute(database, tables, sql, &block)
+      cached_result = fetch(database, tables, sql)
+      if cached_result
+        Rails.logger.debug("REUSE CACHE: #{sql}")
+        return cached_result
       end
+      block.call.tap { |result| add(database, tables, sql, result) }
+    end
 
-      def clear_all
-        @databases = Hash.new do |h, k| 
-          h[k] = Hash.new { |h2, k2| h2[k2] = {} }
-        end
-      end
+    def clear_and_execute(database, table, &block)
+      clear(database, table)
+      block.call
+    end
 
-      def clear(database, table)
-        keys = @databases[database].keys.select { |key| (/##{key}(?:\z|\s)/) }
-        keys.each do |key|
-          @databases[database][key] = {}
-        end
+    def fetch(database, tables, sql)
+      result = @databases[database][tables][sql]
+      return nil unless result
+      return result[:data] unless sync_mode?
+      return updated?(database, tables, result[:timestamp]) ? nil : result[:data]
+    end
+
+    def sync_mode?
+      !!@sync_client
+    end
+
+    def update_modified_timestamp(database, table)
+      @sync_client.write("#{database}+#{table}", Time.now.to_i)
+    end
+
+    def updated?(database, tables, cached_timestamp)
+      tables.any? do |table|
+        next unless updated_timestamp = @sync_client.read("#{database}+#{table}")
+        next if updated_timestamp < cached_timestamp
+        next true
       end
     end
   end

--- a/spec/caching_query_spec.rb
+++ b/spec/caching_query_spec.rb
@@ -83,18 +83,17 @@ module ReuseQueryResults
       end
     end
 
-    context 'with include' do
+    context 'with join' do
       it 'cache result' do
-        Bar.create!(foo_id: Foo.create!)
-        Foo.includes(:bar).first.bar
-        expect(ReuseQueryResults.storage.databases[test_database_name][%w(foos)].keys.size).to eq 1
-        expect(ReuseQueryResults.storage.databases[test_database_name][%w(bars)].keys.size).to eq 1
+        Bar.create!(foo_id: Foo.create!.id)
+        Foo.joins(:bar).first
+        expect(ReuseQueryResults.storage.databases[test_database_name][%w(bars foos)].keys.size).to eq 1
       end
 
       it 'clear cache when insert' do
-        Foo.includes(:bar).first
+        Foo.joins(:bar).first
         Foo.create!
-        expect(ReuseQueryResults.storage.databases[test_database_name][%w(foos)].keys.size).to eq 0
+        expect(ReuseQueryResults.storage.databases[test_database_name][%w(bars foos)].keys.size).to eq 0
       end
     end
 

--- a/spec/caching_query_spec.rb
+++ b/spec/caching_query_spec.rb
@@ -3,99 +3,150 @@ require 'spec_helper'
 
 module ReuseQueryResults
   describe Storage do
-    describe Storage::Memory do
-      def test_database_name
-        Bar.connection.instance_variable_get(:'@config')[:database]
+    before do
+      ReuseQueryResults.storage = ReuseQueryResults::Storage.new
+    end
+
+    def test_database_name
+      Bar.connection.instance_variable_get(:'@config')[:database]
+    end
+
+    def alter_database_name
+      AlterBar.connection.instance_variable_get(:'@config')[:database]
+    end
+
+    describe 'multi databases' do
+      it 'fetch from cache from each databases' do
+        allow(ReuseQueryResults.storage).to receive(:add).and_call_original
+        expect(ReuseQueryResults.storage).to receive(:add).with(test_database_name, %w(bars), anything, anything).once.and_call_original
+        expect(ReuseQueryResults.storage).to receive(:add).with(alter_database_name, %w(bars), anything, anything).once.and_call_original
+        2.times { Bar.first.to_s }
+        2.times { AlterBar.first.to_s }
       end
 
-      def alter_database_name
-        AlterBar.connection.instance_variable_get(:'@config')[:database]
+      it "does not clear by other database's same name table" do
+        Bar.first
+        AlterBar.create!
+        expect(ReuseQueryResults.storage.databases[test_database_name][%w(bars)].keys.size).to eq 1
       end
+    end
 
-      describe 'multi databases' do
-        it 'fetch from cache from each databases' do
-          allow(ReuseQueryResults.storage).to receive(:add).and_call_original
-          expect(ReuseQueryResults.storage).to receive(:add).with(test_database_name, '#bars', anything, anything).once.and_call_original
-          expect(ReuseQueryResults.storage).to receive(:add).with(alter_database_name, '#bars', anything, anything).once.and_call_original
-          2.times { Bar.first.to_s }
-          2.times { AlterBar.first.to_s }
-        end
+    it 'cache result' do
+      Foo.first
+      expect(ReuseQueryResults.storage.databases[test_database_name][%w(foos)].keys.size).to eq 1
+    end
 
-        it "does not clear by other database's same name table" do
-          Bar.first
-          AlterBar.create!
-          expect(ReuseQueryResults.storage.databases[test_database_name]['#bars'].keys.size).to eq 1
-        end
-      end
+    it 'add result first time' do
+      allow(ReuseQueryResults.storage).to receive(:add).and_call_original
+      expect(ReuseQueryResults.storage).to receive(:add).with(test_database_name, %w(foos), anything, anything).once.and_call_original
+      Foo.first
+    end
 
+    it 'fetch from cache second time' do
+      allow(ReuseQueryResults.storage).to receive(:add).and_call_original
+      expect(ReuseQueryResults.storage).to receive(:add).with(test_database_name, %w(foos), anything, anything).once.and_call_original
+      2.times { Foo.first.to_s }
+    end
+
+    it 'clear cache when insert' do
+      Foo.first
+      Foo.create!
+      expect(ReuseQueryResults.storage.databases[test_database_name][%w(foos)].keys.size).to eq 0
+    end
+
+    it 'clear cache when delete' do
+      Foo.create!
+      Foo.first
+      Foo.first.destroy
+      expect(ReuseQueryResults.storage.databases[test_database_name][%w(foos)].keys.size).to eq 0
+    end
+
+    it 'clear cache when update' do
+      Foo.create!(name: 'new')
+      Foo.first
+      Foo.first.update_attributes!(name: 'updated')
+      expect(ReuseQueryResults.storage.databases[test_database_name][%w(foos)].keys.size).to eq 0
+    end
+
+    context 'with join' do
       it 'cache result' do
-        Foo.first
-        expect(ReuseQueryResults.storage.databases[test_database_name]['#foos'].keys.size).to eq 1
-      end
-
-      it 'add result first time' do
-        allow(ReuseQueryResults.storage).to receive(:add).and_call_original
-        expect(ReuseQueryResults.storage).to receive(:add).with(test_database_name, '#foos', anything, anything).once.and_call_original
-        Foo.first
-      end
-
-      it 'fetch from cache second time' do
-        allow(ReuseQueryResults.storage).to receive(:add).and_call_original
-        expect(ReuseQueryResults.storage).to receive(:add).with(test_database_name, '#foos', anything, anything).once.and_call_original
-        2.times { Foo.first.to_s }
+        Foo.joins(:bar).first
+        expect(ReuseQueryResults.storage.databases[test_database_name][%w(bars foos)].keys.size).to eq 1
+        expect(ReuseQueryResults.storage.databases[test_database_name][%w(foos)].keys.size).to eq 0
+        expect(ReuseQueryResults.storage.databases[test_database_name][%w(bars)].keys.size).to eq 0
       end
 
       it 'clear cache when insert' do
-        Foo.first
+        Foo.joins(:bar).first
         Foo.create!
-        expect(ReuseQueryResults.storage.databases[test_database_name]['#foos'].keys.size).to eq 0
+        expect(ReuseQueryResults.storage.databases[test_database_name][%w(bars foos)].keys.size).to eq 0
+      end
+    end
+
+    context 'with include' do
+      it 'cache result' do
+        Bar.create!(foo_id: Foo.create!)
+        Foo.includes(:bar).first.bar
+        expect(ReuseQueryResults.storage.databases[test_database_name][%w(foos)].keys.size).to eq 1
+        expect(ReuseQueryResults.storage.databases[test_database_name][%w(bars)].keys.size).to eq 1
       end
 
-      it 'clear cache when delete' do
+      it 'clear cache when insert' do
+        Foo.includes(:bar).first
         Foo.create!
-        Foo.first
-        Foo.first.destroy
-        expect(ReuseQueryResults.storage.databases[test_database_name]['#foos'].keys.size).to eq 0
+        expect(ReuseQueryResults.storage.databases[test_database_name][%w(foos)].keys.size).to eq 0
       end
+    end
 
-      it 'clear cache when update' do
-        Foo.create!(name: 'new')
-        Foo.first
-        Foo.first.update_attributes!(name: 'updated')
-        expect(ReuseQueryResults.storage.databases[test_database_name]['#foos'].keys.size).to eq 0
-      end
-
-      context 'with join' do
-        it 'cache result' do
-          Foo.joins(:bar).first
-          key = ReuseQueryResults.tables_to_key(%w(foos bars))
-          expect(ReuseQueryResults.storage.databases[test_database_name][key].keys.size).to eq 1
-          expect(ReuseQueryResults.storage.databases[test_database_name]['#foos'].keys.size).to eq 0
-          expect(ReuseQueryResults.storage.databases[test_database_name]['#bars'].keys.size).to eq 0
-        end
-
-        it 'clear cache when insert' do
-          Foo.joins(:bar).first
-          Foo.create!
-          key = ReuseQueryResults.tables_to_key(%w(foos bars))
-          expect(ReuseQueryResults.storage.databases[test_database_name][key].keys.size).to eq 0
+    describe 'sync mode' do
+      let(:sync_client_mock) do
+        double(:sync_client).tap do |client|
+          client.stub(:clear)
         end
       end
 
-      context 'with include' do
-        it 'cache result' do
-          Bar.create!(foo_id: Foo.create!)
-          Foo.includes(:bar).first.bar
-          expect(ReuseQueryResults.storage.databases[test_database_name]['#foos'].keys.size).to eq 1
-          expect(ReuseQueryResults.storage.databases[test_database_name]['#bars'].keys.size).to eq 1
+      before do
+        ReuseQueryResults.storage = ReuseQueryResults::Storage.new(sync_client: sync_client_mock)
+        allow(sync_client_mock).to receive(:write)
+        allow(sync_client_mock).to receive(:read)
+        allow(ReuseQueryResults.storage).to receive(:add).and_call_original
+      end
+
+      it 'sync mode' do
+        expect(ReuseQueryResults.storage).to be_sync_mode
+      end
+
+      it 'update timestamp' do
+        expect(sync_client_mock).to receive(:write).with("#{test_database_name}+foos", kind_of(Numeric))
+        Foo.create!
+      end
+
+      it 'does not reuse query when table updated' do
+        expect(ReuseQueryResults.storage).to receive(:add).with(test_database_name, %w(foos), anything, anything).twice.and_call_original
+        sync_client_mock.stub(:read).with("#{test_database_name}+foos") { (Time.now + 1.day).to_i }
+        2.times { Foo.first }
+      end
+
+      it 'reuse query when table no updated' do
+        expect(ReuseQueryResults.storage).to receive(:add).with(test_database_name, %w(foos), anything, anything).once.and_call_original
+        sync_client_mock.stub(:read).with("#{test_database_name}+foos") { (Time.now - 1.day).to_i }
+        2.times { Foo.first }
+      end
+
+      describe 'joinned table' do
+        it 'does not reuse query when table updated' do
+          expect(ReuseQueryResults.storage).to receive(:add).with(test_database_name, %w(bars foos), anything, anything).twice.and_call_original
+          sync_client_mock.stub(:read).with("#{test_database_name}+bars") { (Time.now + 1.day).to_i }
+          2.times { Foo.joins(:bar).first }
         end
 
-        it 'clear cache when insert' do
-          Foo.includes(:bar).first
-          Foo.create!
-          expect(ReuseQueryResults.storage.databases[test_database_name]['#foos'].keys.size).to eq 0
+        it 'reuse query when table no updated' do
+          expect(ReuseQueryResults.storage).to receive(:add).with(test_database_name, %w(bars foos), anything, anything).once.and_call_original
+          sync_client_mock.stub(:read).with("#{test_database_name}+bars") { (Time.now - 1.day).to_i }
+          2.times { Foo.joins(:bar).first }
         end
       end
     end
+
   end
 end


### PR DESCRIPTION
Add synchronization mode.

```
sync_client = ActiveSupport::Cache.lookup_store(:dalli_store, address)
ReuseQueryResults.storage = ReuseQueryResults::Storage.new(sync_client: sync_client)
```

Record update database timing to store. 
When updated timestamp is newer than cached timestamp, process will refetch results.

"Mysql2::Result" is non-serializable object, so results is not cached to memcache. 
